### PR TITLE
ci: use the org-wide SOREN_PAT (replaces RELEASE_TOKEN)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ secrets.SOREN_PAT }}
 
       - name: 🐰 Setup Bun
         uses: oven-sh/setup-bun@v1


### PR DESCRIPTION
Part of consolidating release tokens on the org-wide `SOREN_PAT` (removing `RELEASE_TOKEN`). NB: requires the SOREN_PAT token's repository access to include this repo.