### PR TITLE
feat(PlanningTimeline): multi-bar rows (rowId), hideBar placeholders & toolbarActions slot

### DIFF
--- a/src/components/DataDisplay/PlanningTimeline/PlanningTimeline.tsx
+++ b/src/components/DataDisplay/PlanningTimeline/PlanningTimeline.tsx
@@ -50,6 +50,7 @@ const PlanningTimeline = <T extends PlanningTimelineTask>({
   renderTooltip,
   isTaskSelected,
   recenterKey,
+  toolbarActions,
   sidebarTitle,
   locale,
   labels,
@@ -81,14 +82,37 @@ const PlanningTimeline = <T extends PlanningTimelineTask>({
     return allTasks.filter((task) => !(task.type === "task" && task.project && collapsed.has(task.project)));
   }, [allTasks]);
 
+  // Visual rows: a project header is always its own row; task rows sharing the same `rowId` (within
+  // the same project group) are merged into a single row carrying one bar per task. A merged row sits
+  // where its first task appears and keeps that first task as its sidebar-cell representative.
+  const { rows: visibleRows, keys: rowKeys } = useMemo(() => {
+    const rows: T[][] = [];
+    const keys: string[] = [];
+    const rowIndexByKey = new Map<string, number>();
+    visibleTasks.forEach((task) => {
+      const mergeKey = task.type === "task" && task.rowId != null ? `row:${task.project ?? ""}::${task.rowId}` : null;
+      if (mergeKey !== null) {
+        const existingIndex = rowIndexByKey.get(mergeKey);
+        if (existingIndex !== undefined) {
+          rows[existingIndex].push(task);
+          return;
+        }
+        rowIndexByKey.set(mergeKey, rows.length);
+      }
+      keys.push(mergeKey ?? task.id);
+      rows.push([task]);
+    });
+    return { keys, rows };
+  }, [visibleTasks]);
+
   const scale = useMemo(() => createTimeScale(allTasks, viewMode, locale), [allTasks, viewMode, locale]);
   const visibleSidebarWidth = sidebarCollapsed ? 0 : sidebarWidth;
 
   const rowVirtualizer = useVirtualizer({
-    count: visibleTasks.length,
+    count: visibleRows.length,
     estimateSize: () => rowHeight,
     // Stable keys let the virtualizer (and React) reuse row elements instead of remounting them.
-    getItemKey: (index) => visibleTasks[index].id,
+    getItemKey: (index) => rowKeys[index],
     getScrollElement: () => scrollRef.current,
     // Rows are fixed-height and cheap — a generous overscan (~20 rows ≈ 2 viewports) keeps fast
     // scrolling from outrunning the window and flashing blank rows.
@@ -256,20 +280,23 @@ const PlanningTimeline = <T extends PlanningTimelineTask>({
           </Button>
         </Stack>
 
-        <ToggleButtonGroup exclusive value={viewMode} size="small" onChange={handleViewModeChange}>
-          <ToggleButton value="day" sx={{ textTransform: "capitalize" }}>
-            {label("day")}
-          </ToggleButton>
-          <ToggleButton value="week" sx={{ textTransform: "capitalize" }}>
-            {label("week")}
-          </ToggleButton>
-          <ToggleButton value="month" sx={{ textTransform: "capitalize" }}>
-            {label("month")}
-          </ToggleButton>
-          <ToggleButton value="year" sx={{ textTransform: "capitalize" }}>
-            {label("year")}
-          </ToggleButton>
-        </ToggleButtonGroup>
+        <Stack direction="row" alignItems="center" spacing={2}>
+          {toolbarActions}
+          <ToggleButtonGroup exclusive value={viewMode} size="small" onChange={handleViewModeChange}>
+            <ToggleButton value="day" sx={{ textTransform: "capitalize" }}>
+              {label("day")}
+            </ToggleButton>
+            <ToggleButton value="week" sx={{ textTransform: "capitalize" }}>
+              {label("week")}
+            </ToggleButton>
+            <ToggleButton value="month" sx={{ textTransform: "capitalize" }}>
+              {label("month")}
+            </ToggleButton>
+            <ToggleButton value="year" sx={{ textTransform: "capitalize" }}>
+              {label("year")}
+            </ToggleButton>
+          </ToggleButtonGroup>
+        </Stack>
       </Stack>
 
       {/* Scrollable grid (vertical = virtualized rows, horizontal = timeline) */}
@@ -338,13 +365,16 @@ const PlanningTimeline = <T extends PlanningTimelineTask>({
             )}
 
             {rowVirtualizer.getVirtualItems().map((virtualRow) => {
-              const task = visibleTasks[virtualRow.index];
-              const isProject = task.type === "project";
-              const selected = !isProject && (isTaskSelected?.(task) ?? false);
+              const row = visibleRows[virtualRow.index];
+              // The first task is the row's representative: it renders the sidebar cell and drives
+              // the project checks (a merged multi-bar row is always made of task rows only).
+              const rowHead = row[0];
+              const isProject = rowHead.type === "project";
+              const rowSelected = !isProject && row.some((task) => isTaskSelected?.(task) ?? false);
 
               return (
                 <Box
-                  key={task.id}
+                  key={rowKeys[virtualRow.index]}
                   sx={{
                     display: "flex",
                     height: rowHeight,
@@ -370,7 +400,7 @@ const PlanningTimeline = <T extends PlanningTimelineTask>({
                         zIndex: 2,
                       }}
                     >
-                      {renderRowContent(task, { onJump, selected, sidebarCollapsed })}
+                      {renderRowContent(rowHead, { onJump, selected: rowSelected, sidebarCollapsed })}
                     </Box>
                   )}
 
@@ -385,29 +415,33 @@ const PlanningTimeline = <T extends PlanningTimelineTask>({
                         (sidebarCollapsed
                           ? { backgroundColor: palette.background.paper, backgroundImage: getBackgroundImageElevation(1) }
                           : { backgroundColor: palette.action.hover })),
-                      ...(selected && { backgroundColor: palette.action.selected }),
+                      ...(rowSelected && { backgroundColor: palette.action.selected }),
                     }}
                   >
                     {/* Group header pinned to the left when the sidebar is collapsed. */}
                     {isProject && sidebarCollapsed && (
                       <Box sx={{ height: "100%", left: 0, maxWidth: sidebarWidth, position: "sticky", zIndex: 2 }}>
-                        {renderRowContent(task, { onJump, selected, sidebarCollapsed })}
+                        {renderRowContent(rowHead, { onJump, selected: rowSelected, sidebarCollapsed })}
                       </Box>
                     )}
 
-                    {!isProject && (
-                      <TaskBar
-                        task={task}
-                        scale={scale}
-                        rowHeight={rowHeight}
-                        sidebarCollapsed={sidebarCollapsed}
-                        selected={selected}
-                        onClick={onClick}
-                        onBarResize={onBarResize}
-                        renderBar={renderBarContent}
-                        renderTooltip={renderTooltip}
-                      />
-                    )}
+                    {!isProject &&
+                      row
+                        .filter((task) => !task.hideBar)
+                        .map((task) => (
+                          <TaskBar
+                            key={task.id}
+                            task={task}
+                            scale={scale}
+                            rowHeight={rowHeight}
+                            sidebarCollapsed={sidebarCollapsed}
+                            selected={isTaskSelected?.(task) ?? false}
+                            onClick={onClick}
+                            onBarResize={onBarResize}
+                            renderBar={renderBarContent}
+                            renderTooltip={renderTooltip}
+                          />
+                        ))}
                   </Box>
                 </Box>
               );

--- a/src/components/DataDisplay/PlanningTimeline/stories/PlanningTimeline.stories.tsx
+++ b/src/components/DataDisplay/PlanningTimeline/stories/PlanningTimeline.stories.tsx
@@ -1,4 +1,4 @@
-import { Paper, Typography } from "@mui/material";
+import { Paper, ToggleButton, ToggleButtonGroup, Typography } from "@mui/material";
 import type { Meta } from "@storybook/react-vite";
 import Template from "@/components/DataDisplay/PlanningTimeline/stories/Templates/Template";
 import { planningTimelineDataGenerator } from "@/components/DataDisplay/PlanningTimeline/stories/utils/planningTimelineDataGenerator";
@@ -40,6 +40,31 @@ FrenchLabels.args = {
   locale: "fr",
   sidebarTitle: "Équipement",
   tasks: planningTimelineDataGenerator(),
+};
+
+export const MultipleBarsPerRow = Template.bind({});
+MultipleBarsPerRow.args = {
+  sidebarTitle: "Equipment",
+  tasks: planningTimelineDataGenerator([
+    { barsPerRow: 3, name: "Rented", statusColor: "success", taskCount: 3 },
+    { barsPerRow: 2, name: "Available soon", statusColor: "info", taskCount: 2 },
+  ]),
+};
+
+export const WithToolbarActions = Template.bind({});
+WithToolbarActions.args = {
+  sidebarTitle: "Equipment",
+  tasks: planningTimelineDataGenerator(),
+  toolbarActions: (
+    <ToggleButtonGroup exclusive size="small" value="status">
+      <ToggleButton value="status" sx={{ textTransform: "none" }}>
+        Status
+      </ToggleButton>
+      <ToggleButton value="category" sx={{ textTransform: "none" }}>
+        Category
+      </ToggleButton>
+    </ToggleButtonGroup>
+  ),
 };
 
 export const CollapsedGroup = Template.bind({});

--- a/src/components/DataDisplay/PlanningTimeline/stories/utils/planningTimelineDataGenerator.ts
+++ b/src/components/DataDisplay/PlanningTimeline/stories/utils/planningTimelineDataGenerator.ts
@@ -9,6 +9,8 @@ interface GeneratorGroup {
   statusColor: PlanningTimelineStatusColor;
   taskCount: number;
   collapsed?: boolean;
+  /** Above 1, each row gets that many bars sharing the same `rowId` (one line per machine). */
+  barsPerRow?: number;
 }
 
 /**
@@ -26,27 +28,33 @@ export const planningTimelineDataGenerator = (
     // Global machine number, continuous across groups (Excavator 1..n).
     const offset = groups.slice(0, groupIndex).reduce((sum, { taskCount }) => sum + taskCount, 0);
 
+    const barsPerRow = Math.max(1, group.barsPerRow ?? 1);
+
     const rows: PlanningTimelineTask[] = Array.from({ length: group.taskCount }, (_, i) => {
-      const start = daysFromNow(i * 4 - 6);
-      const end = daysFromNow(i * 4 + 4);
-      const overdue = group.statusColor === "success" && i === 0;
-      return {
-        end: overdue ? new Date() : end,
-        id: `${group.name}-${i}`,
-        incidents: i === 1 ? [{ incidentDate: daysFromNow(-2) }] : undefined,
-        name: `Excavator ${offset + i + 1}`,
-        overdue,
-        plannedEnd: overdue ? daysFromNow(-3) : undefined,
-        project: group.name,
-        start: overdue ? daysFromNow(-10) : start,
-        statusColor: group.statusColor,
-        type: "task",
-      };
-    });
+      const overdue = group.statusColor === "success" && i === 0 && barsPerRow === 1;
+      // One task per bar; above one bar per row they share a `rowId` and split the row timespan.
+      return Array.from({ length: barsPerRow }, (_, barIndex): PlanningTimelineTask => {
+        const start = daysFromNow(i * 4 - 6 + barIndex * 5);
+        const end = daysFromNow(i * 4 - 6 + barIndex * 5 + 3);
+        return {
+          end: overdue ? new Date() : end,
+          id: `${group.name}-${i}-${barIndex}`,
+          incidents: i === 1 && barIndex === 0 ? [{ incidentDate: daysFromNow(-2) }] : undefined,
+          name: `Excavator ${offset + i + 1}`,
+          overdue,
+          plannedEnd: overdue ? daysFromNow(-3) : undefined,
+          project: group.name,
+          rowId: barsPerRow > 1 ? `${group.name}-${i}` : undefined,
+          start: overdue ? daysFromNow(-10) : start,
+          statusColor: group.statusColor,
+          type: "task",
+        };
+      });
+    }).flat();
 
     const allDates = rows.flatMap((row) => [row.start.getTime(), row.end.getTime()]);
     const header: PlanningTimelineTask = {
-      childCount: rows.length,
+      childCount: group.taskCount,
       end: new Date(Math.max(...allDates)),
       hideChildren: group.collapsed ?? false,
       id: group.name,

--- a/src/components/DataDisplay/PlanningTimeline/test/PlanningTimeline.test.tsx
+++ b/src/components/DataDisplay/PlanningTimeline/test/PlanningTimeline.test.tsx
@@ -1,7 +1,13 @@
 import { fireEvent, render } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import PlanningTimeline from "../PlanningTimeline";
 import type { PlanningTimelineTask } from "../types";
+
+/** jsdom has no layout (elements measure 0×0) — give them a size so the virtualizer renders rows. */
+const mockElementSize = () => {
+  vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockReturnValue(800);
+  vi.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockReturnValue(1200);
+};
 
 const tasks: PlanningTimelineTask[] = [
   { end: new Date(), hideChildren: false, id: "group-1", name: "Group 1", start: new Date(), type: "project" },
@@ -19,6 +25,10 @@ const tasks: PlanningTimelineTask[] = [
 describe("Test <PlanningTimeline/>", () => {
   beforeEach(() => {
     localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("renders the toolbar with the built-in English labels", () => {
@@ -65,5 +75,63 @@ describe("Test <PlanningTimeline/>", () => {
     localStorage.setItem("soren-planning-timeline-view-mode", "bogus");
     const { getByText } = render(<PlanningTimeline tasks={tasks} defaultViewMode="week" />);
     expect(getByText("Week").closest("button")).toHaveClass("Mui-selected");
+  });
+
+  it("merges tasks sharing a rowId into a single row with one bar per task", () => {
+    mockElementSize();
+
+    const DAY = 24 * 60 * 60 * 1000;
+    const multiBarTasks: PlanningTimelineTask[] = [
+      { end: new Date(), id: "group-1", name: "Group 1", start: new Date(), type: "project" },
+      {
+        end: new Date(Date.now() + 2 * DAY),
+        id: "booking-1",
+        name: "Booking 1",
+        project: "group-1",
+        rowId: "equipment-1",
+        start: new Date(),
+        type: "task",
+      },
+      {
+        end: new Date(Date.now() + 6 * DAY),
+        id: "booking-2",
+        name: "Booking 2",
+        project: "group-1",
+        rowId: "equipment-1",
+        start: new Date(Date.now() + 4 * DAY),
+        type: "task",
+      },
+    ];
+
+    const { getByText, queryByText, getAllByText } = render(
+      <PlanningTimeline tasks={multiBarTasks} renderBar={(task) => `bar:${task.id}`} renderRow={(task) => `row:${task.id}`} />,
+    );
+
+    expect(getByText("bar:booking-1")).toBeInTheDocument();
+    expect(getByText("bar:booking-2")).toBeInTheDocument();
+    expect(getAllByText(/^row:/)).toHaveLength(2); // the group header row + the merged equipment row
+    expect(getByText("row:booking-1")).toBeInTheDocument();
+    expect(queryByText("row:booking-2")).not.toBeInTheDocument();
+  });
+
+  it("renders toolbarActions in the toolbar", () => {
+    const { getByText } = render(<PlanningTimeline tasks={tasks} toolbarActions={<button type="button">Group by</button>} />);
+    expect(getByText("Group by")).toBeInTheDocument();
+    expect(getByText("Day")).toBeInTheDocument();
+  });
+
+  it("renders a row but no bar for a hideBar placeholder task", () => {
+    mockElementSize();
+
+    const placeholderTasks: PlanningTimelineTask[] = [
+      { end: new Date(), hideBar: true, id: "idle-1", name: "Idle equipment", start: new Date(), type: "task" },
+    ];
+
+    const { getByText, queryByText } = render(
+      <PlanningTimeline tasks={placeholderTasks} renderBar={(task) => `bar:${task.id}`} renderRow={(task) => `row:${task.id}`} />,
+    );
+
+    expect(getByText("row:idle-1")).toBeInTheDocument();
+    expect(queryByText("bar:idle-1")).not.toBeInTheDocument();
   });
 });

--- a/src/components/DataDisplay/PlanningTimeline/types.ts
+++ b/src/components/DataDisplay/PlanningTimeline/types.ts
@@ -28,6 +28,18 @@ export interface PlanningTimelineTask {
   hideChildren?: boolean;
   /** For task rows: id of the parent project (group) row. */
   project?: string;
+  /**
+   * For task rows: tasks sharing the same `rowId` (within the same `project` group) are laid out on
+   * one single row, each keeping its own bar — e.g. every booking of one equipment on one line. The
+   * left-column cell is rendered from the row's first task; bars paint in array order (later tasks
+   * above earlier ones when they overlap). Omit to keep the default one-bar-per-row layout.
+   */
+  rowId?: string;
+  /**
+   * For task rows: render the row without its bar. Use it as a placeholder to show an empty row —
+   * e.g. an idle equipment with no booking. Its dates only feed the time axis range.
+   */
+  hideBar?: boolean;
   /** Incidents rendered as red hatched day-wide segments on the bar. */
   incidents?: PlanningTimelineIncident[];
   /** Original planned end (before any overdue extension of `end`). */
@@ -87,6 +99,8 @@ export interface PlanningTimelineProps<T extends PlanningTimelineTask = Planning
   isTaskSelected?: (task: T) => boolean;
   /** Opaque value that changes when filters change — the timeline re-centres on today when it does. */
   recenterKey?: string;
+  /** Extra content rendered in the toolbar, just left of the view-mode toggle (e.g. a grouping switch). */
+  toolbarActions?: ReactNode;
   /** Title of the left (frozen) column, also used as the collapse button tooltip. */
   sidebarTitle?: string;
   /** BCP 47 locale for the axis and toolbar date labels (e.g. "fr"). @default "en" */


### PR DESCRIPTION
The supplier backoffice planning displays one row per machine with one bar per booking. `PlanningTimeline` currently enforces one bar per row — this PR adds the three pieces that unlock it, fully backward compatible (no change for existing consumers).

## Changes

- **`rowId`** — tasks sharing the same `rowId` (within the same `project` group) are merged into a single row, one bar per task. Without `rowId` the layout is unchanged.
- **`hideBar`** — a task with `hideBar: true` keeps its row visible without drawing a bar (e.g. an available machine with no booking).
- **`toolbarActions`** — custom content rendered in the toolbar, left of the view-mode toggle (e.g. a group-by switch).

## Tests & stories

- Vitest 36/36 (3 new: rowId merging, hideBar placeholder, toolbarActions rendering)
- New stories: `MultipleBarsPerRow` (via a `barsPerRow` option on the data generator) and `WithToolbarActions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
